### PR TITLE
fix(ske-encrypted-volumes): reference correct kubeconfig resource

### DIFF
--- a/examples/ske-encrypted-volumes/provider.tf
+++ b/examples/ske-encrypted-volumes/provider.tf
@@ -31,8 +31,8 @@ provider "stackit" {
 }
 
 provider "kubernetes" {
-  host                   = yamldecode(stackit_ske_kubeconfig.example.kube_config).clusters.0.cluster.server
-  client_certificate     = base64decode(yamldecode(stackit_ske_kubeconfig.example.kube_config).users.0.user.client-certificate-data)
-  client_key             = base64decode(yamldecode(stackit_ske_kubeconfig.example.kube_config).users.0.user.client-key-data)
-  cluster_ca_certificate = base64decode(yamldecode(stackit_ske_kubeconfig.example.kube_config).clusters.0.cluster.certificate-authority-data)
+  host                   = yamldecode(stackit_ske_kubeconfig.default.kube_config).clusters.0.cluster.server
+  client_certificate     = base64decode(yamldecode(stackit_ske_kubeconfig.default.kube_config).users.0.user.client-certificate-data)
+  client_key             = base64decode(yamldecode(stackit_ske_kubeconfig.default.kube_config).users.0.user.client-key-data)
+  cluster_ca_certificate = base64decode(yamldecode(stackit_ske_kubeconfig.default.kube_config).clusters.0.cluster.certificate-authority-data)
 }


### PR DESCRIPTION
The kubernetes provider referenced stackit_ske_kubeconfig.example, but the resource is declared as default; terraform validate failed with Reference to undeclared resource.

## Description

The `kubernetes` provider referenced `stackit_ske_kubeconfig.example`, but the
resource is declared as `stackit_ske_kubeconfig.default` in `main.tf`, so the
example fails `terraform validate` with "Reference to undeclared resource".
This PR aligns the four references to the actual resource name.

## Checklist

- [x] The CI pipeline passed successfully.
