### PR TITLE
fix(ske-kubernetes-terraform-provider): reference correct kubeconfig

### DIFF
--- a/examples/ske-kubernetes-terraform-provider/main.tf
+++ b/examples/ske-kubernetes-terraform-provider/main.tf
@@ -63,10 +63,10 @@ resource "stackit_ske_kubeconfig" "example" {
 }
 
 provider "kubernetes" {
-  host                   = yamldecode(stackit_ske_kubeconfig.ske_kubeconfig_01.kube_config).clusters[0].cluster.server
-  client_certificate     = base64decode(yamldecode(stackit_ske_kubeconfig.ske_kubeconfig_01.kube_config).users[0].user["client-certificate-data"])
-  client_key             = base64decode(yamldecode(stackit_ske_kubeconfig.ske_kubeconfig_01.kube_config).users[0].user["client-key-data"])
-  cluster_ca_certificate = base64decode(yamldecode(stackit_ske_kubeconfig.ske_kubeconfig_01.kube_config).clusters[0].cluster["certificate-authority-data"])
+  host                   = yamldecode(stackit_ske_kubeconfig.example.kube_config).clusters[0].cluster.server
+  client_certificate     = base64decode(yamldecode(stackit_ske_kubeconfig.example.kube_config).users[0].user["client-certificate-data"])
+  client_key             = base64decode(yamldecode(stackit_ske_kubeconfig.example.kube_config).users[0].user["client-key-data"])
+  cluster_ca_certificate = base64decode(yamldecode(stackit_ske_kubeconfig.example.kube_config).clusters[0].cluster["certificate-authority-data"])
 }
 
 resource "kubernetes_namespace" "example" {


### PR DESCRIPTION
The kubernetes provider referenced stackit_ske_kubeconfig.ske_kubeconfig_01, but the resource is declared as example; terraform validate failed with Reference to undeclared resource.

## Description

The `kubernetes` provider referenced `stackit_ske_kubeconfig.ske_kubeconfig_01`,
but the resource is declared as `stackit_ske_kubeconfig.example`, so the example
failed `terraform validate` with "Reference to undeclared resource". This PR
aligns the four references to the actual resource name. `terraform validate` now
passes cleanly.

## Checklist

- [x] The CI pipeline passed successfully.
