### PR TITLE
fix(ske-observability): remove read-only continue from alert route

### DIFF
--- a/examples/ske-observability-alerting-kube-state-metrics/main.tf
+++ b/examples/ske-observability-alerting-kube-state-metrics/main.tf
@@ -48,8 +48,7 @@ locals {
   alert_config = {
     route = {
       receiver        = "EmailStackit",
-      repeat_interval = "1m",
-      continue        = true
+      repeat_interval = "1m"
     }
     receivers = [
       {

--- a/examples/ske-observability-log-alerts/main.tf
+++ b/examples/ske-observability-log-alerts/main.tf
@@ -48,8 +48,7 @@ locals {
   alert_config = {
     route = {
       receiver        = "EmailStackit",
-      repeat_interval = "1m",
-      continue        = true
+      repeat_interval = "1m"
     }
     receivers = [
       {


### PR DESCRIPTION
route.continue is a read-only (computed) attribute of stackit_observability_instance; setting it broke terraform validate with Invalid Configuration for Read-Only Attribute. Affects both observability examples.

## Description

`route.continue` is a Read-Only (computed) attribute of `stackit_observability_instance`,
but both observability examples set `continue = true` in `local.alert_config.route`, so
they fail `terraform validate`:

    Error: Invalid Configuration for Read-Only Attribute
      with stackit_observability_instance.example
      Cannot set value for this attribute as the provider has marked it as read-only.

Removes the offending line from:
- examples/ske-observability-log-alerts/main.tf
- examples/ske-observability-alerting-kube-state-metrics/main.tf

`continue` is only meaningful on child `route.routes[]`, not the root route, so dropping
it is also semantically correct. 

Ref: provider docs for `stackit_observability_instance`
([route nested schema ](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/observability_instance#nested-schema-for-alert_configroute)→ `continue` listed under Read-Only).

## Checklist

- [x] The CI pipeline passed successfully.
